### PR TITLE
Change branch name from 'branch' to 'develop'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Starting from scratch, follow these steps to set up local repository:
     ```
 4. Create local develop branch
     ```bash
-    git checkout -b branch
+    git checkout -b develop
     push origin main
     ```
 4. **Set `develop` as the default branch for PRs** on GitHub:


### PR DESCRIPTION
Updated instructions to create a local 'develop' branch instead of 'branch'.